### PR TITLE
Update subgpt.py

### DIFF
--- a/subgpt/subgpt.py
+++ b/subgpt/subgpt.py
@@ -6,7 +6,7 @@ import sys
 import tldextract
 
 import dns.resolver
-from EdgeGPT import Chatbot, ConversationStyle
+from EdgeGPT.EdgeGPT import Chatbot, ConversationStyle
 
 parser = argparse.ArgumentParser()
 parser.add_argument('-i', help='file containing subdomains', dest='input_file')


### PR DESCRIPTION
I got this error after installation. 

 › subgpt                                             
Traceback (most recent call last):
  File "/home/kali/.local/bin/subgpt", line 5, in <module>
    from subgpt.subgpt import main
  File "/home/kali/.local/lib/python3.11/site-packages/subgpt/subgpt.py", line 9, in <module>
    from EdgeGPT import Chatbot, ConversationStyle
ImportError: cannot import name 'Chatbot' from 'EdgeGPT' (/home/kali/.local/lib/python3.11/site-packages/EdgeGPT/__init__.py)

then after a quick look in EdgeGPT github noticed they suggest using:

from EdgeGPT.EdgeGPT import Chatbot, ConversationStyle